### PR TITLE
WIP: Allow ScrewStamped msgs to set Screw Axis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,11 +9,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_compile_options(-Winline)
 
 find_package(catkin REQUIRED COMPONENTS
+  affordance_primitive_msgs
   geometry_msgs
   tf2_eigen
 )
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
+    affordance_primitive_msgs
     geometry_msgs
     tf2_eigen
 )

--- a/include/affordance_primitives/affordance_utils.hpp
+++ b/include/affordance_primitives/affordance_utils.hpp
@@ -86,6 +86,6 @@ Eigen::Isometry3d convertPoseToNewFrame(const geometry_msgs::PoseStamped& new_ba
  * @exception Throws a std::runtime_error if the transform cannot be completed
  */
 affordance_primitive_msgs::ScrewStamped transformScrew(const affordance_primitive_msgs::ScrewStamped& input_screw,
-                                        const geometry_msgs::TransformStamped& transform);
+                                                       const geometry_msgs::TransformStamped& transform);
 
 }  // namespace affordance_primitives

--- a/include/affordance_primitives/affordance_utils.hpp
+++ b/include/affordance_primitives/affordance_utils.hpp
@@ -35,7 +35,9 @@
 
 #include <optional>
 
+#include <affordance_primitive_msgs/ScrewStamped.h>
 #include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/TransformStamped.h>
 #include <geometry_msgs/TwistStamped.h>
 
 #include <affordance_primitives/screw_conversions.hpp>
@@ -75,4 +77,15 @@ geometry_msgs::TwistStamped getTwistFromPoses(const geometry_msgs::PoseStamped& 
  */
 Eigen::Isometry3d convertPoseToNewFrame(const geometry_msgs::PoseStamped& new_base_frame,
                                         const geometry_msgs::PoseStamped& transformed_pose);
+
+/**
+ * @brief Transforms a ScrewStamped msg by the prescribed Transform
+ * @param input_screw Screw message to transform
+ * @param transform The transform to perform. The frame_id should match in the input screw
+ * @return The transformed ScrewStamped
+ * @exception Throws a std::runtime_error if the transform cannot be completed
+ */
+affordance_primitive_msgs::ScrewStamped transformScrew(const affordance_primitive_msgs::ScrewStamped& input_screw,
+                                        const geometry_msgs::TransformStamped& transform);
+
 }  // namespace affordance_primitives

--- a/include/affordance_primitives/screw_conversions.hpp
+++ b/include/affordance_primitives/screw_conversions.hpp
@@ -33,6 +33,7 @@
 
 #pragma once
 
+#include <affordance_primitive_msgs/ScrewStamped.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/TwistStamped.h>
 #include <tf2_eigen/tf2_eigen.h>
@@ -74,6 +75,17 @@ inline std::string poseToStr(const geometry_msgs::PoseStamped& pose)
          << "\nZ: " << pose.pose.position.z << "\nQX: " << pose.pose.orientation.x
          << "\nQY: " << pose.pose.orientation.y << "\nQZ: " << pose.pose.orientation.z
          << "\nQW: " << pose.pose.orientation.w;
+  return stream.str();
+}
+
+inline std::string screwMsgToStr(const affordance_primitive_msgs::ScrewStamped& screw)
+{
+  std::stringstream stream;
+  stream << "\nHeader: " << screw.header.frame_id << "\nOrigin X: " << screw.origin.x
+         << "\nOrigin Y: " << screw.origin.y << "\nOrigin Z: " << screw.origin.z << "\nAxis X: " << screw.axis.x
+         << "\nAxis Y: " << screw.axis.y << "\nAxis Z: " << screw.axis.z << "\nPitch: " << screw.is_pure_translation ?
+      "Infinity" :
+      std::to_string(screw.pitch);
   return stream.str();
 }
 

--- a/include/affordance_primitives/screw_conversions.hpp
+++ b/include/affordance_primitives/screw_conversions.hpp
@@ -36,6 +36,7 @@
 #include <affordance_primitive_msgs/ScrewStamped.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/TwistStamped.h>
+#include <geometry_msgs/Transform.h>
 #include <tf2_eigen/tf2_eigen.h>
 
 #include <sstream>
@@ -55,6 +56,73 @@ inline Eigen::Matrix3d getSkewSymmetricMatrix(const Eigen::Vector3d& vec)
   output(2, 0) = -vec(1);
   output(1, 2) = -vec(0);
   output(2, 1) = vec(0);
+
+  return output;
+}
+
+/**
+ * @brief Converts a transformation into an adjoint matrix for transforming twists and wrenches
+ *
+ * Usage: twist_in_A = Adjoint(tf_from_A_to_B) * twist_in_B
+ *
+ * When using this adjoint, it assumes the twist is a 6x1 vector with angular on top [angular ; linear]. The tf2_eigen
+ * library does not convert Twist messages to Eigen Vectors this way, so use the functions included here for converting
+ * between these data types
+ */
+inline Eigen::MatrixXd getAdjointMatrix(const Eigen::Isometry3d& transform)
+{
+  Eigen::MatrixXd adjoint(6, 6);
+
+  // Block matrix with
+  // |R     0|
+  // |[p]R  R|
+  adjoint.block<3, 3>(0, 0) = transform.linear();
+  adjoint.block<3, 3>(0, 3).setZero();
+  adjoint.block<3, 3>(3, 0) = getSkewSymmetricMatrix(transform.translation()) * transform.linear();
+  adjoint.block<3, 3>(3, 3) = transform.linear();
+
+  return adjoint;
+}
+
+/**
+ * @brief Converts a transformation into an adjoint matrix for transforming twists and wrenches
+ *
+ * Usage: twist_in_A = Adjoint(tf_from_A_to_B) * twist_in_B
+ *
+ * When using this adjoint, it assumes the twist is a 6x1 vector with angular on top [angular ; linear]. The tf2_eigen
+ * library does not convert Twist messages to Eigen Vectors this way, so use the functions included here for converting
+ * between these data types
+ */
+inline Eigen::MatrixXd getAdjointMatrix(const geometry_msgs::Transform& transform)
+{
+  return getAdjointMatrix(tf2::transformToEigen(transform));
+}
+
+/**
+ * @brief Converts a twist message to a 6x1 vector with [angular ; linear]
+ */
+inline Eigen::VectorXd twistToVector(const geometry_msgs::Twist& twist)
+{
+  Eigen::Vector3d angular, linear;
+  tf2::fromMsg(twist.angular, angular);
+  tf2::fromMsg(twist.linear, linear);
+
+  Eigen::VectorXd output(6);
+  output.head(3) = angular;
+  output.tail(3) = linear;
+
+  return output;
+}
+
+/**
+ * @brief Converts a 6x1 vector with [angular ; linear] to a twist message
+ */
+inline geometry_msgs::Twist vectorToTwist(const Eigen::VectorXd& vec)
+{
+  geometry_msgs::Twist output;
+
+  tf2::toMsg(vec.head(3), output.angular);
+  tf2::toMsg(vec.tail(3), output.linear);
 
   return output;
 }

--- a/include/affordance_primitives/screw_conversions.hpp
+++ b/include/affordance_primitives/screw_conversions.hpp
@@ -80,12 +80,16 @@ inline std::string poseToStr(const geometry_msgs::PoseStamped& pose)
 
 inline std::string screwMsgToStr(const affordance_primitive_msgs::ScrewStamped& screw)
 {
+  std::string pitch;
+  if (screw.is_pure_translation)
+    pitch = "Infinity";
+  else
+    pitch = std::to_string(screw.pitch);
+
   std::stringstream stream;
   stream << "\nHeader: " << screw.header.frame_id << "\nOrigin X: " << screw.origin.x
          << "\nOrigin Y: " << screw.origin.y << "\nOrigin Z: " << screw.origin.z << "\nAxis X: " << screw.axis.x
-         << "\nAxis Y: " << screw.axis.y << "\nAxis Z: " << screw.axis.z << "\nPitch: " << screw.is_pure_translation ?
-      "Infinity" :
-      std::to_string(screw.pitch);
+         << "\nAxis Y: " << screw.axis.y << "\nAxis Z: " << screw.axis.z << "\nPitch: " << pitch;
   return stream.str();
 }
 

--- a/include/affordance_primitives/screw_motion.hpp
+++ b/include/affordance_primitives/screw_motion.hpp
@@ -33,6 +33,7 @@
 
 #pragma once
 
+#include <affordance_primitive_msgs/ScrewStamped.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/TwistStamped.h>
 
@@ -53,6 +54,7 @@ Eigen::Vector3d calculateLinearVelocity(const Eigen::Vector3d& axis, const Eigen
 class ScrewAxis
 {
 public:
+  ScrewAxis();
   ScrewAxis(const std::string moving_frame_name, bool is_pure_translation = false);
 
   // Setup Screw Axis
@@ -84,6 +86,13 @@ public:
   {
     return setScrewAxis(Eigen::toMsg(origin_pose), axis, pitch);
   };
+
+  /**
+   * @brief Sets up the Screw axis using a ScrewStamped message
+   * @param screw_msg The input message. The screw axis must be non-zero here
+   * @return True if the setup was successful, false otherwise
+   */
+  bool setScrewAxis(const affordance_primitive_msgs::ScrewStamped& screw_msg);
 
   /**
    * @brief Sets up the Screw axis, a twist message (TODO: implement)

--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>s
 
+  <depend>affordance_primitive_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>tf2_eigen</depend>
 

--- a/src/affordance_utils.cpp
+++ b/src/affordance_utils.cpp
@@ -117,14 +117,14 @@ affordance_primitive_msgs::ScrewStamped transformScrew(const affordance_primitiv
   output.header.frame_id = transform.child_frame_id;
 
   // Convert to Eigen types
-  auto tf_old_to_new = tf2::transformToEigen(transform.transform);
+  auto tf_new_to_old = (tf2::transformToEigen(transform.transform)).inverse();
   Eigen::Vector3d screw_axis, screw_origin;
   tf2::fromMsg(input_screw.axis, screw_axis);
   tf2::fromMsg(input_screw.origin, screw_origin);
 
   // Perform the transform
-  Eigen::Vector3d rotated_axis = tf_old_to_new.linear() * screw_axis;
-  Eigen::Vector3d transformed_origin = tf_old_to_new.linear() * screw_origin + tf_old_to_new.translation();
+  Eigen::Vector3d rotated_axis = tf_new_to_old.linear() * screw_axis;
+  Eigen::Vector3d transformed_origin = tf_new_to_old.translation() + tf_new_to_old.linear() * screw_origin;
 
   // Convert back from Eigen types
   output.origin = tf2::toMsg(transformed_origin);

--- a/src/affordance_utils.cpp
+++ b/src/affordance_utils.cpp
@@ -101,7 +101,7 @@ Eigen::Isometry3d convertPoseToNewFrame(const geometry_msgs::PoseStamped& new_ba
 }
 
 affordance_primitive_msgs::ScrewStamped transformScrew(const affordance_primitive_msgs::ScrewStamped& input_screw,
-                                        const geometry_msgs::TransformStamped& transform)
+                                                       const geometry_msgs::TransformStamped& transform)
 {
   if (input_screw.header.frame_id == transform.child_frame_id)
   {

--- a/src/affordance_utils.cpp
+++ b/src/affordance_utils.cpp
@@ -100,4 +100,35 @@ Eigen::Isometry3d convertPoseToNewFrame(const geometry_msgs::PoseStamped& new_ba
   return tf_root_to_new_base_frame.inverse() * tf_root_to_transformed_pose;
 }
 
+affordance_primitive_msgs::ScrewStamped transformScrew(const affordance_primitive_msgs::ScrewStamped& input_screw,
+                                        const geometry_msgs::TransformStamped& transform)
+{
+  if (input_screw.header.frame_id == transform.child_frame_id)
+  {
+    // Already in the correct frame
+    return input_screw;
+  }
+  else if (input_screw.header.frame_id != transform.header.frame_id)
+  {
+    throw std::runtime_error("Cannot transform screw: transform frame does not match incoming screw frame");
+  }
+
+  affordance_primitive_msgs::ScrewStamped output;
+  output.header.frame_id = transform.child_frame_id;
+
+  // Convert to Eigen types
+  auto tf_old_to_new = tf2::transformToEigen(transform.transform);
+  Eigen::Vector3d screw_axis, screw_origin;
+  tf2::fromMsg(input_screw.axis, screw_axis);
+  tf2::fromMsg(input_screw.origin, screw_origin);
+
+  // Perform the transform
+  Eigen::Vector3d rotated_axis = tf_old_to_new.linear() * screw_axis;
+  Eigen::Vector3d transformed_origin = tf_old_to_new.linear() * screw_origin + tf_old_to_new.translation();
+
+  // Convert back from Eigen types
+  output.origin = tf2::toMsg(transformed_origin);
+  tf2::toMsg(rotated_axis, output.axis);
+  return output;
+}
 }  // namespace affordance_primitives

--- a/src/screw_motion.cpp
+++ b/src/screw_motion.cpp
@@ -42,6 +42,13 @@ Eigen::Vector3d calculateLinearVelocity(const Eigen::Vector3d& axis, const Eigen
   return pitch_component - rotation_component;
 }
 
+ScrewAxis::ScrewAxis()
+{
+  axis_.setZero();
+  origin_.setZero();
+  translation_component_.setZero();
+}
+
 ScrewAxis::ScrewAxis(const std::string moving_frame_name, bool is_pure_translation)
   : moving_frame_name_(moving_frame_name), is_pure_translation_(is_pure_translation)
 {
@@ -99,6 +106,22 @@ bool ScrewAxis::setScrewAxis(const geometry_msgs::Pose& origin_pose, const Eigen
     translation_component_ = calculateLinearVelocity(axis_, origin_, pitch_);
   }
   return true;
+}
+
+bool ScrewAxis::setScrewAxis(const affordance_primitive_msgs::ScrewStamped& screw_msg)
+{
+  // Override moving frame and translation information
+  moving_frame_name_ = screw_msg.header.frame_id;
+  is_pure_translation_ = screw_msg.is_pure_translation;
+
+  // Convert message types
+  geometry_msgs::Pose origin_pose;
+  origin_pose.position = screw_msg.origin;
+  Eigen::Vector3d eigen_axis;
+  tf2::fromMsg(screw_msg.axis, eigen_axis);
+
+  // Set up screw axis using origin-axis formulation
+  return setScrewAxis(origin_pose, eigen_axis, screw_msg.pitch);
 }
 
 geometry_msgs::TwistStamped ScrewAxis::getTwist(double theta_dot) const


### PR DESCRIPTION
1. Adds constructor to create a screw axis from the ROS message type
2. Adds some useful utility and conversion functions (transforming screws, getting the adjoint)

Probably still needs a test for the screw transform function, will work on that before merging