### PR TITLE
Add ParameterManager plugin

### DIFF
--- a/affordance_primitives/CMakeLists.txt
+++ b/affordance_primitives/CMakeLists.txt
@@ -11,6 +11,7 @@ add_compile_options(-Winline)
 find_package(catkin REQUIRED COMPONENTS
   affordance_primitive_msgs
   geometry_msgs
+  pluginlib
   tf2_eigen
   tf2_ros
 )
@@ -18,6 +19,7 @@ find_package(catkin REQUIRED COMPONENTS
 set(THIS_PACKAGE_INCLUDE_DEPENDS
     affordance_primitive_msgs
     geometry_msgs
+    pluginlib
     tf2_eigen
     tf2_ros
 )
@@ -38,7 +40,10 @@ include_directories(
 )
 
 add_library(${PROJECT_NAME} SHARED
+  include/${PROJECT_NAME}/empty_parameter_manager.hpp
+  include/${PROJECT_NAME}/parameter_manager.hpp
   src/affordance_utils.cpp
+  src/parameter_manager_plugins.cpp
   src/screw_axis.cpp
   src/screw_execution.cpp)
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
@@ -55,6 +60,8 @@ install(
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
+
+install(FILES plugins.xml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 #############
 ## TESTING ##

--- a/affordance_primitives/CMakeLists.txt
+++ b/affordance_primitives/CMakeLists.txt
@@ -78,4 +78,7 @@ if(CATKIN_ENABLE_TESTING)
 
   add_rostest_gtest(test_screw_execution test/test_screw_execution.test test/test_screw_execution.cpp)
   target_link_libraries(test_screw_execution ${catkin_LIBRARIES} ${PROJECT_NAME})
+
+  add_rostest_gtest(test_parameter_manager test/test_parameter_manager.test test/test_parameter_manager.cpp)
+  target_link_libraries(test_parameter_manager ${catkin_LIBRARIES} ${PROJECT_NAME})
 endif()

--- a/affordance_primitives/include/affordance_primitives/empty_parameter_manager.hpp
+++ b/affordance_primitives/include/affordance_primitives/empty_parameter_manager.hpp
@@ -1,0 +1,67 @@
+///////////////////////////////////////////////////////////////////////////////
+//      Title     : empty_parameter_manager.h
+//      Project   : affordance_primitives
+//      Created   : 12/29/2021
+//      Author    : Adam Pettinger
+//      Copyright : Copyright© The University of Texas at Austin, 2014-2021. All
+//      rights reserved.
+//
+//          All files within this directory are subject to the following, unless
+//          an alternative license is explicitly included within the text of
+//          each file.
+//
+//          This software and documentation constitute an unpublished work
+//          and contain valuable trade secrets and proprietary information
+//          belonging to the University. None of the foregoing material may be
+//          copied or duplicated or disclosed without the express, written
+//          permission of the University. THE UNIVERSITY EXPRESSLY DISCLAIMS ANY
+//          AND ALL WARRANTIES CONCERNING THIS SOFTWARE AND DOCUMENTATION,
+//          INCLUDING ANY WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+//          PARTICULAR PURPOSE, AND WARRANTIES OF PERFORMANCE, AND ANY WARRANTY
+//          THAT MIGHT OTHERWISE ARISE FROM COURSE OF DEALING OR USAGE OF TRADE.
+//          NO WARRANTY IS EITHER EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF
+//          THE SOFTWARE OR DOCUMENTATION. Under no circumstances shall the
+//          University be liable for incidental, special, indirect, direct or
+//          consequential damages or loss of profits, interruption of business,
+//          or related expenses which may arise from use of software or
+//          documentation, including but not limited to those resulting from
+//          defects in software and/or documentation, or loss or inaccuracy of
+//          data of any kind.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <ros/ros.h>
+#include <affordance_primitives/parameter_manager.hpp>
+
+#include <utility>
+
+namespace affordance_primitives
+{
+/**
+ * An example of a ParameterManager plugin implementation that is trivial
+ */
+class EmptyParameterManager : public affordance_primitives::ParameterManager
+{
+public:
+  EmptyParameterManager(){};
+  void initialize(const ros::NodeHandle& nh)
+  {
+    nh_ = ros::NodeHandle(nh);
+  }
+
+  /** Tries to set a robot's parameters
+   *
+   * @param params The parameters to get set
+   * @return The first value is true if everything was set correctly, second
+   * value is a string that provides logging messages
+   */
+  std::pair<bool, std::string> setParameters(const affordance_primitives::AffordanceParameter& params)
+  {
+    return std::make_pair(true, "");
+  };
+
+  ~EmptyParameterManager(){};
+};
+}  // namespace affordance_primitives

--- a/affordance_primitives/include/affordance_primitives/parameter_manager.hpp
+++ b/affordance_primitives/include/affordance_primitives/parameter_manager.hpp
@@ -1,0 +1,64 @@
+///////////////////////////////////////////////////////////////////////////////
+//      Title     : parameter_manager.h
+//      Project   : affordance_primitives
+//      Created   : 12/17/2021
+//      Author    : Adam Pettinger
+//      Copyright : Copyright© The University of Texas at Austin, 2014-2021. All
+//      rights reserved.
+//
+//          All files within this directory are subject to the following, unless
+//          an alternative license is explicitly included within the text of
+//          each file.
+//
+//          This software and documentation constitute an unpublished work
+//          and contain valuable trade secrets and proprietary information
+//          belonging to the University. None of the foregoing material may be
+//          copied or duplicated or disclosed without the express, written
+//          permission of the University. THE UNIVERSITY EXPRESSLY DISCLAIMS ANY
+//          AND ALL WARRANTIES CONCERNING THIS SOFTWARE AND DOCUMENTATION,
+//          INCLUDING ANY WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+//          PARTICULAR PURPOSE, AND WARRANTIES OF PERFORMANCE, AND ANY WARRANTY
+//          THAT MIGHT OTHERWISE ARISE FROM COURSE OF DEALING OR USAGE OF TRADE.
+//          NO WARRANTY IS EITHER EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF
+//          THE SOFTWARE OR DOCUMENTATION. Under no circumstances shall the
+//          University be liable for incidental, special, indirect, direct or
+//          consequential damages or loss of profits, interruption of business,
+//          or related expenses which may arise from use of software or
+//          documentation, including but not limited to those resulting from
+//          defects in software and/or documentation, or loss or inaccuracy of
+//          data of any kind.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <ros/ros.h>
+
+#include <affordance_primitives/msg_types.hpp>
+#include <utility>
+
+namespace affordance_primitives
+{
+/**
+ * Manages setting up Affordance Primitive parameters for a robot
+ */
+class ParameterManager
+{
+public:
+  virtual void initialize(const ros::NodeHandle& nh) = 0;
+
+  /** Tries to set a robot's parameters
+   *
+   * @param params The parameters to get set
+   * @return The first value is true if everything was set correctly, second
+   * value is a string that provides logging messages
+   */
+  virtual std::pair<bool, std::string> setParameters(const affordance_primitives::AffordanceParameter& params) = 0;
+
+  virtual ~ParameterManager(){};
+
+protected:
+  ParameterManager(){};
+  ros::NodeHandle nh_;
+};
+}  // namespace affordance_primitives

--- a/affordance_primitives/package.xml
+++ b/affordance_primitives/package.xml
@@ -13,6 +13,7 @@
 
   <depend>affordance_primitive_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>pluginlib</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_ros</depend>
 
@@ -22,5 +23,6 @@
 
   <export>
     <build_type>catkin</build_type>
+    <affordance_primitives plugin="${prefix}/plugins.xml" />
   </export>
 </package>

--- a/affordance_primitives/plugins.xml
+++ b/affordance_primitives/plugins.xml
@@ -1,0 +1,5 @@
+<library path="lib/libaffordance_primitives">
+  <class type="affordance_primitives::EmptyParameterManager" base_class_type="affordance_primitives::ParameterManager">
+    <description>A trivial case for examples and default behavior</description>
+  </class>
+</library>

--- a/affordance_primitives/src/parameter_manager_plugins.cpp
+++ b/affordance_primitives/src/parameter_manager_plugins.cpp
@@ -1,0 +1,5 @@
+#include <pluginlib/class_list_macros.h>
+#include <affordance_primitives/empty_parameter_manager.hpp>
+#include <affordance_primitives/parameter_manager.hpp>
+
+PLUGINLIB_EXPORT_CLASS(affordance_primitives::EmptyParameterManager, affordance_primitives::ParameterManager)

--- a/affordance_primitives/test/test_parameter_manager.cpp
+++ b/affordance_primitives/test/test_parameter_manager.cpp
@@ -1,0 +1,69 @@
+///////////////////////////////////////////////////////////////////////////////
+//      Title     : test_parameter_manager.cpp
+//      Project   : affordance_primitives
+//      Created   : 01/20/2022
+//      Author    : Adam Pettinger
+//      Copyright : Copyright© The University of Texas at Austin, 2014-2022. All
+//      rights reserved.
+//
+//          All files within this directory are subject to the following, unless
+//          an alternative license is explicitly included within the text of
+//          each file.
+//
+//          This software and documentation constitute an unpublished work
+//          and contain valuable trade secrets and proprietary information
+//          belonging to the University. None of the foregoing material may be
+//          copied or duplicated or disclosed without the express, written
+//          permission of the University. THE UNIVERSITY EXPRESSLY DISCLAIMS ANY
+//          AND ALL WARRANTIES CONCERNING THIS SOFTWARE AND DOCUMENTATION,
+//          INCLUDING ANY WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+//          PARTICULAR PURPOSE, AND WARRANTIES OF PERFORMANCE, AND ANY WARRANTY
+//          THAT MIGHT OTHERWISE ARISE FROM COURSE OF DEALING OR USAGE OF TRADE.
+//          NO WARRANTY IS EITHER EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF
+//          THE SOFTWARE OR DOCUMENTATION. Under no circumstances shall the
+//          University be liable for incidental, special, indirect, direct or
+//          consequential damages or loss of profits, interruption of business,
+//          or related expenses which may arise from use of software or
+//          documentation, including but not limited to those resulting from
+//          defects in software and/or documentation, or loss or inaccuracy of
+//          data of any kind.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#include <gtest/gtest.h>
+
+#include <affordance_primitives/empty_parameter_manager.hpp>
+#include <affordance_primitives/msg_types.hpp>
+#include <pluginlib/class_loader.h>
+
+TEST(ParameterManager, test_empty_parameter_manager)
+{
+  // Load plugin
+  pluginlib::ClassLoader<affordance_primitives::ParameterManager> plugin_loader(
+      "affordance_primitives", "affordance_primitives::ParameterManager");
+  boost::shared_ptr<affordance_primitives::ParameterManager> param_manager;
+  ASSERT_NO_THROW(param_manager = plugin_loader.createInstance("affordance_primitives::EmptyParameterManager"));
+
+  // Initialize plugin
+  ros::NodeHandle nh;
+  ASSERT_NO_THROW(param_manager->initialize(nh));
+
+  // Test basic functionality
+  affordance_primitives::AffordanceParameter parameters;
+  std::pair<bool, std::string> out;
+  ASSERT_NO_THROW(out = param_manager->setParameters(parameters));
+  EXPECT_TRUE(out.first);
+  EXPECT_TRUE(out.second.empty());
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "test_parameter_manager");
+  testing::InitGoogleTest(&argc, argv);
+
+  ros::AsyncSpinner spinner(8);
+  spinner.start();
+
+  int result = RUN_ALL_TESTS();
+  return result;
+}

--- a/affordance_primitives/test/test_parameter_manager.test
+++ b/affordance_primitives/test/test_parameter_manager.test
@@ -1,0 +1,3 @@
+<launch>
+  <test test-name="test_parameter_manager" pkg="affordance_primitives" type="test_parameter_manager" time-limit="15" />
+</launch>


### PR DESCRIPTION
This adds the Paramater Manager plugin and a trivial example of one (useful as an example, and for simulation)

The manager takes an affordance parameter message and then can interface with the robotic system - for example to set admittance control parameters. Doing this as a plugin allows custom code for unique robot systems