### PR TITLE
Add executor

### DIFF
--- a/affordance_primitive_msgs/action/AffordancePrimitive.action
+++ b/affordance_primitive_msgs/action/AffordancePrimitive.action
@@ -1,12 +1,12 @@
 # Ask to lookup a known frame in the tf tree. "moving_to_task_frame" is ignored in this case
-byte LOOKUP=0
+int8 LOOKUP=0
 
 # Provide a transform to the moving frame. "moving_frame_name" is ignored in this case
 # "moving_to_task_frame" is the transform from the moving frame (e.g. gripper) to the task frame (where the screw is defined)
-byte PROVIDED=1
+int8 PROVIDED=1
 
 # Source of moving frame
-byte moving_frame_source
+int8 moving_frame_source
 
 # Moving frame input
 string moving_frame_name
@@ -30,15 +30,15 @@ affordance_primitive_msgs/APRobotParameter robot_params
 
 ---
 
-byte INVALID_RESULT=0
-byte SUCCESS=1
-byte STOP_REQUESTED=2
-byte PARAM_FAILURE=3
-byte FT_VIOLATION=4
-byte KIN_VIOLATION=5
-byte TIME_OUT=6
+int8 INVALID_RESULT=0
+int8 SUCCESS=1
+int8 STOP_REQUESTED=2
+int8 PARAM_FAILURE=3
+int8 FT_VIOLATION=4
+int8 KIN_VIOLATION=5
+int8 TIME_OUT=6
 
-byte result
+int8 result
 
 ---
 

--- a/affordance_primitive_msgs/action/AffordancePrimitive.action
+++ b/affordance_primitive_msgs/action/AffordancePrimitive.action
@@ -19,10 +19,10 @@ affordance_primitive_msgs/ScrewStamped screw
 float64 task_impedance_translation
 float64 task_impedance_rotation
 
-# Maximum velocity to move along the screw
+# Maximum velocity to move along the screw. It is unsigned and will be considered same sign as "screw_distance"
 float64 theta_dot
 
-# The distance to move along the screw. Meters (pure translation case), Radians (otherwise)
+# The (signed) distance to move along the screw. Meters (pure translation case), Radians (otherwise)
 float64 screw_distance
 
 # The robot configs/parameters to use during this AP move

--- a/affordance_primitives/CMakeLists.txt
+++ b/affordance_primitives/CMakeLists.txt
@@ -38,6 +38,7 @@ include_directories(
 )
 
 add_library(${PROJECT_NAME} SHARED
+  include/${PROJECT_NAME}/ap_executor/ap_executor.hpp
   include/${PROJECT_NAME}/configs_interface/empty_parameter_manager.hpp
   include/${PROJECT_NAME}/configs_interface/parameter_manager.hpp
   include/${PROJECT_NAME}/screw_model/screw_axis.hpp
@@ -45,6 +46,7 @@ add_library(${PROJECT_NAME} SHARED
   include/${PROJECT_NAME}/task_estimator/kinematic_task_estimator.hpp
   include/${PROJECT_NAME}/task_estimator/task_estimator.hpp
   include/${PROJECT_NAME}/task_monitor/task_monitor.hpp
+  src/ap_executor/ap_executor.cpp
   src/configs_interface/empty_parameter_manager.cpp
   src/screw_model/affordance_utils.cpp
   src/screw_model/screw_axis.cpp

--- a/affordance_primitives/CMakeLists.txt
+++ b/affordance_primitives/CMakeLists.txt
@@ -95,4 +95,7 @@ if(CATKIN_ENABLE_TESTING)
 
   add_rostest_gtest(test_task_monitor test/test_task_monitor.test test/test_task_monitor.cpp)
   target_link_libraries(test_task_monitor ${catkin_LIBRARIES} ${PROJECT_NAME})
+
+  add_rostest_gtest(test_ap_executor test/test_ap_executor.test test/test_ap_executor.cpp)
+  target_link_libraries(test_ap_executor ${catkin_LIBRARIES} ${PROJECT_NAME})
 endif()

--- a/affordance_primitives/include/affordance_primitives/ap_common.hpp
+++ b/affordance_primitives/include/affordance_primitives/ap_common.hpp
@@ -36,27 +36,15 @@
 
 namespace affordance_primitives
 {
-enum ExecutionResult
-{
-  INVALID_RESULT,
-  SUCCESS,
-  STOP_REQUESTED,
-  PARAM_FAILURE,
-  FT_VIOLATION,
-  KIN_VIOLATION,
-  TIME_OUT
-};
+const std::unordered_map<int, std::string> EXECUTION_RESULT_MAP({ { 0, "INVALID RESULT" },
+                                                                  { 1, "SUCCESS" },
+                                                                  { 2, "STOP REQUESTED" },
+                                                                  { 3, "PARAMETER FAILURE" },
+                                                                  { 4, "FORCE TORQUE VIOLATION" },
+                                                                  { 5, "KINEMATIC VIOLATION" },
+                                                                  { 6, "TIMED OUT" } });
 
-const std::unordered_map<ExecutionResult, std::string>
-    EXECUTION_RESULT_MAP({ { ExecutionResult::INVALID_RESULT, "INVALID RESULT" },
-                           { ExecutionResult::SUCCESS, "SUCCESS" },
-                           { ExecutionResult::STOP_REQUESTED, "STOP REQUESTED" },
-                           { ExecutionResult::PARAM_FAILURE, "PARAMETER FAILURE" },
-                           { ExecutionResult::FT_VIOLATION, "FORCE TORQUE VIOLATION" },
-                           { ExecutionResult::KIN_VIOLATION, "KINEMATIC VIOLATION" },
-                           { ExecutionResult::TIME_OUT, "TIMED OUT" } });
-
-inline std::string to_string(const ExecutionResult input)
+inline std::string to_string(const int input)
 {
   return EXECUTION_RESULT_MAP.at(input);
 }

--- a/affordance_primitives/include/affordance_primitives/ap_executor/ap_executor.hpp
+++ b/affordance_primitives/include/affordance_primitives/ap_executor/ap_executor.hpp
@@ -1,0 +1,152 @@
+///////////////////////////////////////////////////////////////////////////////
+//      Title     : ap_executor.hpp
+//      Project   : affordance_primitives
+//      Created   : 01/21/2021
+//      Author    : Adam Pettinger
+//      Copyright : Copyright© The University of Texas at Austin, 2014-2022. All
+//      rights reserved.
+//
+//          All files within this directory are subject to the following, unless
+//          an alternative license is explicitly included within the text of
+//          each file.
+//
+//          This software and documentation constitute an unpublished work
+//          and contain valuable trade secrets and proprietary information
+//          belonging to the University. None of the foregoing material may be
+//          copied or duplicated or disclosed without the express, written
+//          permission of the University. THE UNIVERSITY EXPRESSLY DISCLAIMS ANY
+//          AND ALL WARRANTIES CONCERNING THIS SOFTWARE AND DOCUMENTATION,
+//          INCLUDING ANY WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+//          PARTICULAR PURPOSE, AND WARRANTIES OF PERFORMANCE, AND ANY WARRANTY
+//          THAT MIGHT OTHERWISE ARISE FROM COURSE OF DEALING OR USAGE OF TRADE.
+//          NO WARRANTY IS EITHER EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF
+//          THE SOFTWARE OR DOCUMENTATION. Under no circumstances shall the
+//          University be liable for incidental, special, indirect, direct or
+//          consequential damages or loss of profits, interruption of business,
+//          or related expenses which may arise from use of software or
+//          documentation, including but not limited to those resulting from
+//          defects in software and/or documentation, or loss or inaccuracy of
+//          data of any kind.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <actionlib/server/simple_action_server.h>
+#include <pluginlib/class_loader.h>
+#include <ros/ros.h>
+
+#include <affordance_primitives/ap_common.hpp>
+#include <affordance_primitives/configs_interface/parameter_manager.hpp>
+#include <affordance_primitives/msg_types.hpp>
+#include <affordance_primitives/screw_model/screw_execution.hpp>
+#include <affordance_primitives/task_estimator/task_estimator.hpp>
+#include <affordance_primitives/task_monitor/task_monitor.hpp>
+
+#include <optional>
+#include <mutex>
+
+namespace affordance_primitives
+{
+enum Mode
+{
+  INACTIVE,
+  EXECUTING
+};
+
+/**
+ * Stores parameters needed for execution of APs
+ */
+struct ExecutorParameters
+{
+  // Plugins
+  std::string param_manager_plugin_name;
+  std::string task_estimator_plugin_name;
+
+  // Topics
+  std::string monitor_ft_topic_name;
+};
+
+/** Changes AP feedback to be within limits given in goal
+ *
+ * @param params The parameters containing the limits
+ * @param feedback The feedback that will be changed to be within limits
+ * @param epsilon Range within which to consider 0, or limit unset
+ */
+void enforceAPLimits(const APRobotParameter& params, AffordancePrimitiveFeedback& feedback, const double epsilon = 1e-8);
+
+/**
+ * Manages the execution of an Affordance Primitive as an Action. A client will need to interface with this class to
+ * actually run an AP
+ *
+ */
+class APExecutor
+{
+public:
+  /** Constructor
+   *
+   * @param nh ROS node handle
+   * @param action_name the name the AP executor action will take
+   */
+  APExecutor(const ros::NodeHandle& nh, const std::string action_name);
+
+  ~APExecutor()
+  {
+    stop();
+  };
+
+  /** Sets up and starts the action server
+   *
+   * @param params A number of parameters necessary for execution
+   * @return true if successfully initialized, false otherwise
+   */
+  bool initialize(const ExecutorParameters& params);
+
+  /* \brief Stops the current action */
+  void stop();
+
+protected:
+  /** Performs a single Affordance Primitive screw motion
+   *
+   * @param ap_goal The screw-primitive to move with
+   * @return The result of the execution
+   */
+  AffordancePrimitiveResult execute(const affordance_primitive_msgs::AffordancePrimitiveGoalConstPtr& goal);
+
+  /** Carries out the setting of the passed parameters
+   *
+   * @param parameters Parameter object defining this move's parameters
+   * @return true if parameters changed successfully, false otherwise
+   */
+  bool updateParams(const APRobotParameter& parameters);
+
+  /** Does post-execution reset like resetting dims, stopping motion, etc
+   *
+   * @return True if successful, false otherwise
+   */
+  bool postExecuteReset();
+
+  // node handle
+  ros::NodeHandle nh_;
+
+  // Action server
+  actionlib::SimpleActionServer<AffordancePrimitiveAction> action_server_;
+
+  // This manages setting the parameters for a robot
+  std::shared_ptr<pluginlib::ClassLoader<ParameterManager>> pm_loader_;
+  boost::shared_ptr<ParameterManager> parameter_manager_;
+
+  // This estimates the task angle
+  std::shared_ptr<pluginlib::ClassLoader<TaskEstimator>> te_loader_;
+  boost::shared_ptr<TaskEstimator> task_estimator_;
+
+  // Hold the current mode of operation
+  Mode current_mode_{ INACTIVE };
+  mutable std::mutex mode_mutex_;
+
+  // The monitor obejct for getting the execution status
+  std::unique_ptr<TaskMonitor> monitor_;
+
+  std::unique_ptr<APScrewExecutor> screw_executor_;
+};
+}  // namespace affordance_primitives

--- a/affordance_primitives/include/affordance_primitives/task_monitor/task_monitor.hpp
+++ b/affordance_primitives/include/affordance_primitives/task_monitor/task_monitor.hpp
@@ -70,13 +70,13 @@ public:
    * Blocks until a result is found
    * @return The result after waiting
    */
-  ExecutionResult waitForResult();
+  AffordancePrimitiveResult waitForResult();
 
   /**
    * Grabs the result of the monitoring
    * @return The result. If there is none, a std::nullopt is returned
    */
-  std::optional<ExecutionResult> getResult();
+  std::optional<AffordancePrimitiveResult> getResult();
 
   /**
    * Cancels the monitor
@@ -100,7 +100,7 @@ private:
   ros::Time end_time_;
 
   // We need a result to report at the end
-  ExecutionResult result_;
+  AffordancePrimitiveResult result_;
 
   // Hold onto parameters during a monitor session
   APRobotParameter parameters_;
@@ -123,6 +123,6 @@ private:
   std::queue<WrenchStamped> last_wrench_msgs_;
 
   // Check if AP is violated
-  std::optional<ExecutionResult> checkForViolaton(const APRobotParameter& params);
+  std::optional<AffordancePrimitiveResult> checkForViolaton(const APRobotParameter& params);
 };
 }  // namespace affordance_primitives

--- a/affordance_primitives/src/ap_executor/ap_executor.cpp
+++ b/affordance_primitives/src/ap_executor/ap_executor.cpp
@@ -1,0 +1,245 @@
+#include <math.h>
+
+#include <affordance_primitives/ap_executor/ap_executor.hpp>
+#include <affordance_primitives/screw_model/affordance_utils.hpp>
+
+namespace affordance_primitives
+{
+void enforceAPLimits(const APRobotParameter& params, AffordancePrimitiveFeedback& feedback, const double epsilon)
+{
+  // Convert EE velocity twist and limits to Eigen
+  Eigen::Matrix<double, 6, 1> twist_limit = CartesianFloatToVector(params.max_ee_velocity);
+  Eigen::Matrix<double, 6, 1> twist_requested;
+  tf2::fromMsg(feedback.moving_frame_twist.twist, twist_requested);
+
+  // Apply twist limit
+  Eigen::Matrix<double, 6, 1> scale = twist_requested.cwiseQuotient(twist_limit).cwiseAbs();
+  if (scale.maxCoeff() > 1)
+  {
+    twist_requested /= scale.maxCoeff();
+  }
+
+  // Convert wrench and limits to Eigen
+  Eigen::Matrix<double, 6, 1> wrench_limit = CartesianFloatToVector(params.max_wrench);
+  Eigen::Matrix<double, 6, 1> wrench_requested = WrenchToVector(feedback.expected_wrench.wrench);
+
+  // Check for limit along each dimension
+  for (size_t i = 0; i < 6; i++)
+  {
+    if (fabs(wrench_limit[i]) > epsilon)
+    {
+      if (wrench_requested[i] < -1 * wrench_limit[i] || wrench_requested[i] > wrench_limit[i])
+      {
+        wrench_requested[i] = copysign(wrench_limit[i], wrench_requested[i]);
+      }
+    }
+  }
+
+  // Check for total magnitude
+  const double scale_force = wrench_requested.head(3).norm() / params.max_force;
+  if (scale_force > 1.0)
+  {
+    wrench_requested.head(3) /= scale_force;
+  }
+  const double scale_torque = wrench_requested.tail(3).norm() / params.max_torque;
+  if (scale_torque > 1.0)
+  {
+    wrench_requested.tail(3) /= scale_torque;
+  }
+
+  // Convert back to message
+  feedback.moving_frame_twist.twist = tf2::toMsg(twist_requested);
+  feedback.expected_wrench.wrench = VectorToWrench(wrench_requested);
+}
+
+APExecutor::APExecutor(const ros::NodeHandle& nh, const std::string action_name)
+  : nh_(nh), action_server_(nh_, action_name, boost::bind(&APExecutor::execute, this, _1), false)
+{
+}
+
+bool APExecutor::initialize(const ExecutorParameters& params)
+{
+  // Load ParameterManager
+  pm_loader_ = std::make_shared<pluginlib::ClassLoader<ParameterManager>>("affordance_primitives",
+                                                                          "affordance_primitives::ParameterManager");
+  try
+  {
+    parameter_manager_ = pm_loader_->createInstance(params.param_manager_plugin_name);
+    parameter_manager_->initialize(nh_);
+  }
+  catch (pluginlib::PluginlibException& ex)
+  {
+    ROS_ERROR("Parameter Manager plugin failed to load, error was: %s", ex.what());
+    return false;
+  }
+
+  // Load TaskEstimator
+  te_loader_ = std::make_shared<pluginlib::ClassLoader<TaskEstimator>>("affordance_primitives",
+                                                                       "affordance_primitives::TaskEstimator");
+  try
+  {
+    task_estimator_ = te_loader_->createInstance(params.task_estimator_plugin_name);
+    task_estimator_->initialize(nh_);
+  }
+  catch (pluginlib::PluginlibException& ex)
+  {
+    ROS_ERROR("Task Estimator plugin failed to load, error was: %s", ex.what());
+    return false;
+  }
+
+  // Create the execution monitor
+  monitor_ = std::make_unique<TaskMonitor>(nh_, params.monitor_ft_topic_name);
+
+  // This handles the screw math
+  screw_executor_ = std::make_unique<APScrewExecutor>();
+
+  action_server_.start();
+  return true;
+}
+
+AffordancePrimitiveResult APExecutor::execute(const affordance_primitive_msgs::AffordancePrimitiveGoalConstPtr& goal)
+{
+  // End any currently running task
+  stop();
+
+  AffordancePrimitiveResult ap_result;
+
+  // Update parameters
+  if (!updateParams(goal->robot_params))
+  {
+    ap_result.result = ap_result.PARAM_FAILURE;
+    action_server_.setSucceeded(ap_result);
+    return ap_result;
+  }
+
+  // Check input for errors
+  const double epislon = 1e-8;
+  if (fabs(goal->theta_dot) < epislon)
+  {
+    ROS_ERROR("No velocity set, skipping");
+    ap_result.result = ap_result.PARAM_FAILURE;
+    action_server_.setSucceeded(ap_result);
+    return ap_result;
+  }
+  if (fabs(goal->screw_distance) < epislon)
+  {
+    ap_result.result = ap_result.SUCCESS;
+    action_server_.setSucceeded(ap_result);
+    return ap_result;
+  }
+
+  // Set current mode
+  {
+    const std::lock_guard<std::mutex> lock(mode_mutex_);
+    current_mode_ = EXECUTING;
+  }
+
+  // Start the execution monitor
+  const double timeout = 2 * fabs(goal->screw_distance / goal->theta_dot);  // Allow 2x expected time
+  monitor_->startMonitor(goal->robot_params, timeout);
+
+  // Execute commands while monitoring
+  ros::Rate loop_rate(100);
+  ap_result.result = ap_result.INVALID_RESULT;
+
+  // Start estimating task
+  if (!task_estimator_->resetTaskEstimation(0))
+  {
+    stop();
+    ap_result.result = ap_result.KIN_VIOLATION;
+    action_server_.setSucceeded(ap_result);
+    return ap_result;
+  }
+
+  while (ros::ok())
+  {
+    // Check executor status
+    {
+      const std::lock_guard<std::mutex> lock(mode_mutex_);
+      if (current_mode_ != EXECUTING)
+      {
+        ap_result.result = ap_result.STOP_REQUESTED;
+        break;
+      }
+    }
+    // Check if the monitor has ended
+    std::optional<AffordancePrimitiveResult> monitor_result = monitor_->getResult();
+    if (monitor_result.has_value())
+    {
+      ap_result = monitor_result.value();
+      break;
+    }
+    // Otherwise, send commands
+    else
+    {
+      AffordancePrimitiveFeedback ap_feedback;
+      if (!screw_executor_->getScrewTwist(*goal, ap_feedback))
+      {
+        ap_result.result = ap_result.KIN_VIOLATION;
+        break;
+      }
+
+      // Check if we have reached the goal
+      std::optional<double> total_delta_theta = task_estimator_->estimateTaskAngle(*goal);
+      if (!total_delta_theta.has_value())
+      {
+        ap_result.result = ap_result.KIN_VIOLATION;
+        break;
+      }
+      else if (total_delta_theta.value() >= fabs(goal->screw_distance))
+      {
+        ap_result.result = ap_result.SUCCESS;
+        break;
+      }
+
+      // Publish feedback
+      ap_feedback.moving_frame_twist.header.stamp = ros::Time::now();
+      enforceAPLimits(goal->robot_params, ap_feedback);
+      action_server_.publishFeedback(ap_feedback);
+
+      loop_rate.sleep();
+    }
+  }
+
+  // Cleanup
+  stop();
+  postExecuteReset();
+
+  action_server_.setSucceeded(ap_result);
+  return ap_result;
+}
+
+void APExecutor::stop()
+{
+  // Stop the monitor
+  if (monitor_)
+  {
+    monitor_->stopMonitor();
+  }
+
+  // Set the mode to inactive
+  const std::lock_guard<std::mutex> lock(mode_mutex_);
+  current_mode_ = INACTIVE;
+}
+
+bool APExecutor::updateParams(const APRobotParameter& parameters)
+{
+  auto set_params = parameter_manager_->setParameters(parameters);
+  if (!set_params.first)
+  {
+    ROS_ERROR_STREAM("Could not set parameters, error was: " << set_params.second);
+    return false;
+  }
+
+  return true;
+}
+
+bool APExecutor::postExecuteReset()
+{
+  // We want to publish a 0-motion twist just in case things are still moving
+  AffordancePrimitiveFeedback ap_feedback;
+  action_server_.publishFeedback(ap_feedback);
+
+  return true;
+}
+}  // namespace affordance_primitives

--- a/affordance_primitives/src/screw_model/screw_execution.cpp
+++ b/affordance_primitives/src/screw_model/screw_execution.cpp
@@ -45,10 +45,13 @@ bool APScrewExecutor::getScrewTwist(const AffordancePrimitiveGoal& req, Affordan
     return false;
   }
 
+  // Set the sign of the velocity cmd to be same as requested delta
+  const double theta_dot = copysign(req.theta_dot, req.screw_distance);
+
   // Calculate commanded twist in Task frame
   ScrewAxis screw_axis;
   screw_axis.setScrewAxis(req.screw);
-  TwistStamped twist_in_task_frame = screw_axis.getTwist(req.theta_dot);
+  TwistStamped twist_in_task_frame = screw_axis.getTwist(theta_dot);
 
   // Convert twist to EE frame using the adjoint
   Eigen::Matrix<double, 6, 1> eigen_twist_task_frame;

--- a/affordance_primitives/test/test_ap_executor.cpp
+++ b/affordance_primitives/test/test_ap_executor.cpp
@@ -1,0 +1,178 @@
+///////////////////////////////////////////////////////////////////////////////
+//      Title     : test_ap_executor.cpp
+//      Project   : affordance_primitives
+//      Created   : 03/28/2022
+//      Author    : Adam Pettinger
+//      Copyright : Copyright© The University of Texas at Austin, 2014-2022. All
+//      rights reserved.
+//
+//          All files within this directory are subject to the following, unless
+//          an alternative license is explicitly included within the text of
+//          each file.
+//
+//          This software and documentation constitute an unpublished work
+//          and contain valuable trade secrets and proprietary information
+//          belonging to the University. None of the foregoing material may be
+//          copied or duplicated or disclosed without the express, written
+//          permission of the University. THE UNIVERSITY EXPRESSLY DISCLAIMS ANY
+//          AND ALL WARRANTIES CONCERNING THIS SOFTWARE AND DOCUMENTATION,
+//          INCLUDING ANY WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+//          PARTICULAR PURPOSE, AND WARRANTIES OF PERFORMANCE, AND ANY WARRANTY
+//          THAT MIGHT OTHERWISE ARISE FROM COURSE OF DEALING OR USAGE OF TRADE.
+//          NO WARRANTY IS EITHER EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF
+//          THE SOFTWARE OR DOCUMENTATION. Under no circumstances shall the
+//          University be liable for incidental, special, indirect, direct or
+//          consequential damages or loss of profits, interruption of business,
+//          or related expenses which may arise from use of software or
+//          documentation, including but not limited to those resulting from
+//          defects in software and/or documentation, or loss or inaccuracy of
+//          data of any kind.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+#include <tf2_eigen/tf2_eigen.h>
+
+#include <affordance_primitives/ap_executor/ap_executor.hpp>
+#include <affordance_primitives/msg_types.hpp>
+
+constexpr double EPSILON = 1e-4;
+
+class APExecutorTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    // Robot params
+    params.max_wrench.rot_x = 5;
+    params.max_wrench.rot_y = 5;
+    params.max_wrench.rot_z = 5;
+    params.max_wrench.trans_x = 50;
+    params.max_wrench.trans_y = 50;
+    params.max_wrench.trans_z = 50;
+    params.max_torque = 7.5;
+    params.max_force = 75;
+    params.max_ee_velocity.rot_x = 0.1;
+    params.max_ee_velocity.rot_y = 0.1;
+    params.max_ee_velocity.rot_z = 0.1;
+    params.max_ee_velocity.trans_x = 0.5;
+    params.max_ee_velocity.trans_y = 0.5;
+    params.max_ee_velocity.trans_z = 0.5;
+
+    // Exec params
+    executor_params.monitor_ft_topic_name = "/ft";
+    executor_params.param_manager_plugin_name = "affordance_primitives::EmptyParameterManager";
+    executor_params.task_estimator_plugin_name = "affordance_primitives::KinematicTaskEstimator";
+  }
+
+  // void TearDown() override {}
+
+  affordance_primitives::APRobotParameter params;
+  affordance_primitives::ExecutorParameters executor_params;
+};
+
+TEST_F(APExecutorTest, enforce_individual_limits)
+{
+  // Set feedback that will violate individual limits but not total limits
+  affordance_primitives::AffordancePrimitiveFeedback feedback;
+  feedback.expected_wrench.wrench.torque.x = -5.5;
+  feedback.expected_wrench.wrench.torque.y = 5.5;
+  feedback.expected_wrench.wrench.force.z = -51;
+  feedback.expected_wrench.wrench.force.y = 55;
+  feedback.expected_wrench.wrench.force.x = 1;
+  feedback.moving_frame_twist.twist.angular.x = -0.2;
+  feedback.moving_frame_twist.twist.linear.y = 0.4;
+
+  // Check that we enforce the limits
+  ASSERT_NO_THROW(affordance_primitives::enforceAPLimits(params, feedback));
+  EXPECT_NEAR(feedback.expected_wrench.wrench.torque.x, -5, EPSILON);
+  EXPECT_NEAR(feedback.expected_wrench.wrench.torque.y, 5, EPSILON);
+  EXPECT_NEAR(feedback.expected_wrench.wrench.force.z, -50, EPSILON);
+  EXPECT_NEAR(feedback.expected_wrench.wrench.force.y, 50, EPSILON);
+  EXPECT_NEAR(feedback.expected_wrench.wrench.force.x, 1, EPSILON);
+  EXPECT_NEAR(feedback.moving_frame_twist.twist.angular.x, -0.1, EPSILON);
+  EXPECT_NEAR(feedback.moving_frame_twist.twist.linear.y, 0.2, EPSILON);
+  EXPECT_NEAR(feedback.moving_frame_twist.twist.linear.z, 0.0, EPSILON);
+}
+
+TEST_F(APExecutorTest, enforce_total_limits)
+{
+  // Set a feedback that violates the total wrench
+  affordance_primitives::AffordancePrimitiveFeedback feedback;
+  feedback.expected_wrench.wrench.force.x = 49;
+  feedback.expected_wrench.wrench.force.y = -49;
+  feedback.expected_wrench.wrench.force.z = -49;
+  feedback.expected_wrench.wrench.torque.x = -4.9;
+  feedback.expected_wrench.wrench.torque.y = -4.9;
+  feedback.expected_wrench.wrench.torque.z = 4.9;
+
+  // Check that the expected wrench was scaled down to be within limits
+  ASSERT_NO_THROW(affordance_primitives::enforceAPLimits(params, feedback));
+  Eigen::Vector3d force, torque;
+  tf2::fromMsg(feedback.expected_wrench.wrench.force, force);
+  tf2::fromMsg(feedback.expected_wrench.wrench.torque, torque);
+  EXPECT_NEAR(force.norm(), 75, EPSILON);
+  EXPECT_NEAR(torque.norm(), 7.5, EPSILON);
+}
+
+TEST_F(APExecutorTest, enforce_no_limits)
+{
+  // Change some params to unenforced
+  params.max_torque = 0;
+  params.max_wrench.trans_y = 0;
+  params.max_ee_velocity.trans_x = 0;
+
+  // Set some feedback that would violate prior limits
+  affordance_primitives::AffordancePrimitiveFeedback feedback;
+  feedback.expected_wrench.wrench.force.y = 70;
+  feedback.expected_wrench.wrench.torque.x = -4.9;
+  feedback.expected_wrench.wrench.torque.y = -4.9;
+  feedback.expected_wrench.wrench.torque.z = 4.9;
+  feedback.moving_frame_twist.twist.linear.x = 100;
+  feedback.moving_frame_twist.twist.angular.z = 0.05;
+
+  // Check that no values were changed
+  ASSERT_NO_THROW(affordance_primitives::enforceAPLimits(params, feedback));
+  EXPECT_NEAR(feedback.expected_wrench.wrench.force.y, 70, EPSILON);
+  EXPECT_NEAR(feedback.expected_wrench.wrench.torque.x, -4.9, EPSILON);
+  EXPECT_NEAR(feedback.expected_wrench.wrench.torque.y, -4.9, EPSILON);
+  EXPECT_NEAR(feedback.expected_wrench.wrench.torque.z, 4.9, EPSILON);
+  EXPECT_NEAR(feedback.moving_frame_twist.twist.linear.x, 100, EPSILON);
+  EXPECT_NEAR(feedback.moving_frame_twist.twist.angular.z, 0.05, EPSILON);
+}
+
+TEST_F(APExecutorTest, initialize_and_end_properly)
+{
+  ros::NodeHandle nh;
+
+  // Try initializing with valid plugins, should not throw
+  std::shared_ptr<affordance_primitives::APExecutor> executor;
+  bool init_result = false;
+  ASSERT_NO_THROW(executor = std::make_shared<affordance_primitives::APExecutor>(nh, "action_name"));
+  ASSERT_NO_THROW(init_result = executor->initialize(executor_params));
+  EXPECT_TRUE(init_result);
+
+  // Should not throw when we destruct the object
+  ASSERT_NO_THROW(executor.reset());
+
+  // Should fail gracefully when we initialize it with invalid plugin names
+  executor_params.param_manager_plugin_name = "invalid_plugin";
+  init_result = false;
+  ASSERT_NO_THROW(executor = std::make_shared<affordance_primitives::APExecutor>(nh, "action_name"));
+  ASSERT_NO_THROW(init_result = executor->initialize(executor_params));
+  EXPECT_FALSE(init_result);
+  ASSERT_NO_THROW(executor.reset());
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "test_ap_executor");
+  testing::InitGoogleTest(&argc, argv);
+
+  ros::AsyncSpinner spinner(8);
+  spinner.start();
+
+  int result = RUN_ALL_TESTS();
+  return result;
+}

--- a/affordance_primitives/test/test_ap_executor.test
+++ b/affordance_primitives/test/test_ap_executor.test
@@ -1,0 +1,3 @@
+<launch>
+  <test test-name="test_ap_executor" pkg="affordance_primitives" type="test_ap_executor" time-limit="15" />
+</launch>


### PR DESCRIPTION
This adds the AP Executor, which manages the rest of the AP components during a contact task.

1. Adds executor
2. Adds tests for the executor. More are needed, but will be added later
3. Changed Monitor and Executor to using the action result message internally instead of another enum