### PR TITLE
Add trajectory generation for a whole AP move

### DIFF
--- a/affordance_primitive_msgs/CMakeLists.txt
+++ b/affordance_primitive_msgs/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
 add_message_files(
   FILES
   APRobotParameter.msg
+  AffordanceTrajectory.msg
   AffordanceWaypoint.msg
   CartesianBool.msg
   CartesianFloat.msg

--- a/affordance_primitive_msgs/CMakeLists.txt
+++ b/affordance_primitive_msgs/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
 add_message_files(
   FILES
   APRobotParameter.msg
+  AffordanceWaypoint.msg
   CartesianBool.msg
   CartesianFloat.msg
   ScrewStamped.msg

--- a/affordance_primitive_msgs/action/AffordancePrimitive.action
+++ b/affordance_primitive_msgs/action/AffordancePrimitive.action
@@ -3,6 +3,7 @@ int8 LOOKUP=0
 
 # Provide a transform to the moving frame. "moving_frame_name" is ignored in this case
 # "moving_to_task_frame" is the transform from the moving frame (e.g. gripper) to the task frame (where the screw is defined)
+# This is only really useful for testing/debugging as this will be constant (i.e. won't change/move during execution)
 int8 PROVIDED=1
 
 # Source of moving frame
@@ -47,3 +48,7 @@ geometry_msgs/TwistStamped moving_frame_twist
 
 # Wrench required in the EE frame
 geometry_msgs/WrenchStamped expected_wrench
+
+# Just for convenience, we return the TF moving -> task frame
+# This is useful so a client using this feedback doesn't have to look it up again
+geometry_msgs/TransformStamped tf_moving_to_task

--- a/affordance_primitive_msgs/action/AffordancePrimitive.action
+++ b/affordance_primitive_msgs/action/AffordancePrimitive.action
@@ -3,7 +3,6 @@ int8 LOOKUP=0
 
 # Provide a transform to the moving frame. "moving_frame_name" is ignored in this case
 # "moving_to_task_frame" is the transform from the moving frame (e.g. gripper) to the task frame (where the screw is defined)
-# This is only really useful for testing/debugging as this will be constant (i.e. won't change/move during execution)
 int8 PROVIDED=1
 
 # Source of moving frame

--- a/affordance_primitive_msgs/msg/AffordanceTrajectory.msg
+++ b/affordance_primitive_msgs/msg/AffordanceTrajectory.msg
@@ -1,0 +1,7 @@
+# Defines a Cartesian trajectory
+
+# Every waypoint, wrench, twist, etc is defined in this frame
+Header header
+
+# The trajectory
+AffordanceWaypoint[] trajectory

--- a/affordance_primitive_msgs/msg/AffordanceWaypoint.msg
+++ b/affordance_primitive_msgs/msg/AffordanceWaypoint.msg
@@ -3,11 +3,11 @@
 # The duration after the trajectory start this waypoint should be reached in
 duration time_from_start
 
-# The pose of the waypoint. The header frame_id gives the frame this is defined with respect to
-geometry_msgs/PoseStamped pose
+# The pose of the waypoint
+geometry_msgs/Pose pose
 
-# The velocity that is required at this waypoint. Note that this is given in the waypoint's frame (e.g. this twist is body-centric)
+# The velocity that is required at this waypoint
 geometry_msgs/Twist twist
 
-# The wrench that must be applied at this waypoint. Note that this is given in the waypoint's frame (e.g. this wrench is body-centric)
+# The wrench that must be applied at this waypoint
 geometry_msgs/Wrench wrench

--- a/affordance_primitive_msgs/msg/AffordanceWaypoint.msg
+++ b/affordance_primitive_msgs/msg/AffordanceWaypoint.msg
@@ -1,0 +1,13 @@
+# Defines a Cartesian waypoint for an affordance trajectory
+
+# The duration after the trajectory start this waypoint should be reached in
+duration time_from_start
+
+# The pose of the waypoint. The header frame_id gives the frame this is defined with respect to
+geometry_msgs/PoseStamped pose
+
+# The velocity that is required at this waypoint. Note that this is given in the waypoint's frame (e.g. this twist is body-centric)
+geometry_msgs/Twist twist
+
+# The wrench that must be applied at this waypoint. Note that this is given in the waypoint's frame (e.g. this wrench is body-centric)
+geometry_msgs/Wrench wrench

--- a/affordance_primitives/CMakeLists.txt
+++ b/affordance_primitives/CMakeLists.txt
@@ -31,6 +31,7 @@ catkin_package(
     affordance_primitive_msgs
     geometry_msgs
     pluginlib
+    tf2_eigen
     tf2_ros
 )
 

--- a/affordance_primitives/include/affordance_primitives/msg_types.hpp
+++ b/affordance_primitives/include/affordance_primitives/msg_types.hpp
@@ -42,6 +42,7 @@
 
 #include <affordance_primitive_msgs/APRobotParameter.h>
 #include <affordance_primitive_msgs/AffordancePrimitiveAction.h>
+#include <affordance_primitive_msgs/AffordanceWaypoint.h>
 #include <affordance_primitive_msgs/CartesianFloat.h>
 #include <affordance_primitive_msgs/ScrewStamped.h>
 #include <geometry_msgs/PointStamped.h>
@@ -59,6 +60,7 @@ using AffordancePrimitiveAction = affordance_primitive_msgs::AffordancePrimitive
 using AffordancePrimitiveGoal = affordance_primitive_msgs::AffordancePrimitiveGoal;
 using AffordancePrimitiveFeedback = affordance_primitive_msgs::AffordancePrimitiveFeedback;
 using AffordancePrimitiveResult = affordance_primitive_msgs::AffordancePrimitiveResult;
+using AffordanceWaypoint = affordance_primitive_msgs::AffordanceWaypoint;
 using CartesianFloat = affordance_primitive_msgs::CartesianFloat;
 using ScrewStamped = affordance_primitive_msgs::ScrewStamped;
 using PointStamped = geometry_msgs::PointStamped;

--- a/affordance_primitives/include/affordance_primitives/msg_types.hpp
+++ b/affordance_primitives/include/affordance_primitives/msg_types.hpp
@@ -42,6 +42,7 @@
 
 #include <affordance_primitive_msgs/APRobotParameter.h>
 #include <affordance_primitive_msgs/AffordancePrimitiveAction.h>
+#include <affordance_primitive_msgs/AffordanceTrajectory.h>
 #include <affordance_primitive_msgs/AffordanceWaypoint.h>
 #include <affordance_primitive_msgs/CartesianFloat.h>
 #include <affordance_primitive_msgs/ScrewStamped.h>
@@ -60,6 +61,7 @@ using AffordancePrimitiveAction = affordance_primitive_msgs::AffordancePrimitive
 using AffordancePrimitiveGoal = affordance_primitive_msgs::AffordancePrimitiveGoal;
 using AffordancePrimitiveFeedback = affordance_primitive_msgs::AffordancePrimitiveFeedback;
 using AffordancePrimitiveResult = affordance_primitive_msgs::AffordancePrimitiveResult;
+using AffordanceTrajectory = affordance_primitive_msgs::AffordanceTrajectory;
 using AffordanceWaypoint = affordance_primitive_msgs::AffordanceWaypoint;
 using CartesianFloat = affordance_primitive_msgs::CartesianFloat;
 using ScrewStamped = affordance_primitive_msgs::ScrewStamped;

--- a/affordance_primitives/include/affordance_primitives/screw_model/affordance_utils.hpp
+++ b/affordance_primitives/include/affordance_primitives/screw_model/affordance_utils.hpp
@@ -109,6 +109,26 @@ Eigen::MatrixXd getAdjointMatrix(const Eigen::Isometry3d & transform);
 Eigen::MatrixXd getAdjointMatrix(const Transform & transform);
 
 /**
+ * @brief Transforms a twist to a new frame
+ * Equation: twist_in_A = Adjoint(tf_from_A_to_B) * twist_in_B
+ * @param twist The twist to transform, with format [linear ; angular]
+ * @param tf The transformation from the new frame to old frame
+ * @return The transformed twist, with format [linear ; angular]
+ */
+Eigen::Matrix<double, 6, 1> transformTwist(
+  const Eigen::Matrix<double, 6, 1> & twist, const Eigen::Isometry3d & tf);
+
+/**
+ * @brief Transforms a twist to a new frame
+ * Equation: twist_in_A = Adjoint(tf_from_A_to_B) * twist_in_B
+ * @param twist The twist to transform, with format [linear ; angular]
+ * @param tf The transformation from the new frame to old frame
+ * @return The transformed twist, with format [linear ; angular]
+ */
+Eigen::Matrix<double, 6, 1> transformWrench(
+  const Eigen::Matrix<double, 6, 1> & twist, const Eigen::Isometry3d & tf);
+
+/**
  * @brief Gets the pretty string format for a TwistStamped message
  */
 std::string twistToStr(const TwistStamped & twist);

--- a/affordance_primitives/include/affordance_primitives/screw_model/affordance_utils.hpp
+++ b/affordance_primitives/include/affordance_primitives/screw_model/affordance_utils.hpp
@@ -119,14 +119,14 @@ Eigen::Matrix<double, 6, 1> transformTwist(
   const Eigen::Matrix<double, 6, 1> & twist, const Eigen::Isometry3d & tf);
 
 /**
- * @brief Transforms a twist to a new frame
- * Equation: twist_in_A = Adjoint(tf_from_A_to_B) * twist_in_B
- * @param twist The twist to transform, with format [linear ; angular]
+ * @brief Transforms a wrench to a new frame
+ * Equation: wrench_in_A = Adjoint(tf_from_B_to_A)^T * wrench_in_B
+ * @param wrench The wrench to transform, with format [force ; torque]
  * @param tf The transformation from the new frame to old frame
- * @return The transformed twist, with format [linear ; angular]
+ * @return The transformed wrench, with format [force ; torque]
  */
 Eigen::Matrix<double, 6, 1> transformWrench(
-  const Eigen::Matrix<double, 6, 1> & twist, const Eigen::Isometry3d & tf);
+  const Eigen::Matrix<double, 6, 1> & wrench, const Eigen::Isometry3d & tf);
 
 /**
  * @brief Gets the pretty string format for a TwistStamped message

--- a/affordance_primitives/include/affordance_primitives/screw_model/screw_axis.hpp
+++ b/affordance_primitives/include/affordance_primitives/screw_model/screw_axis.hpp
@@ -35,6 +35,7 @@
 
 #include <affordance_primitives/msg_types.hpp>
 #include <affordance_primitives/screw_model/affordance_utils.hpp>
+#include <vector>
 
 namespace affordance_primitives
 {
@@ -107,6 +108,14 @@ public:
    * @return The calculated transformation, defined with respect to the frame of the Screw Axis
    */
   Eigen::Isometry3d getTF(double delta_theta) const;
+
+  /**
+   * @brief Runs "getTF" a bunch of times to generate a waypoint trajectory
+   * @param theta_step The delta_theta to apply at each step. Larger = coarser trajectory
+   * @param num_steps The number of waypoints. num_steps * theta_steps = total delta_theta
+   * @return A vector of waypoints
+   */
+  std::vector<Eigen::Isometry3d> getWaypoints(double theta_step, size_t num_steps);
 
   // Getters
   std::string getFrame() const { return moving_frame_name_; };

--- a/affordance_primitives/include/affordance_primitives/screw_model/screw_execution.hpp
+++ b/affordance_primitives/include/affordance_primitives/screw_model/screw_execution.hpp
@@ -81,14 +81,14 @@ public:
 
   bool getScrewTwist(const AffordancePrimitiveGoal & req, AffordancePrimitiveFeedback & feedback);
 
-private:
   /**
    * @brief Gets the TF from the moving frame to task frame, either by looking it up or checking the passed one
    * @param req The AP request containing frame information
    * @return If request invalid or lookup failed, returns nullopt. Otherwise, the TF is the location of the task frame with respect to the moving frame
    */
-  std::optional<Eigen::Isometry3d> getTFInfo(const AffordancePrimitiveGoal & req);
+  std::optional<TransformStamped> getTFInfo(const AffordancePrimitiveGoal & req);
 
+private:
   // TF Lookup
   tf2_ros::Buffer tfBuffer_;
   tf2_ros::TransformListener tfListener_;

--- a/affordance_primitives/include/affordance_primitives/screw_model/screw_execution.hpp
+++ b/affordance_primitives/include/affordance_primitives/screw_model/screw_execution.hpp
@@ -79,8 +79,10 @@ public:
 
   ~APScrewExecutor(){};
 
-  bool getScrewTwist(const AffordancePrimitiveGoal & req, AffordancePrimitiveFeedback & feedback);
-  std::vector<AffordanceWaypoint> getScrewWaypoints(const AffordancePrimitiveGoal & req, size_t num_steps);
+  bool setStreamingCommands(
+    const AffordancePrimitiveGoal & req, AffordancePrimitiveFeedback & feedback);
+  std::vector<AffordanceWaypoint> getTrajectoryCommands(
+    const AffordancePrimitiveGoal & req, size_t num_steps);
 
   /**
    * @brief Gets the TF from the moving frame to task frame, either by looking it up or checking the passed one

--- a/affordance_primitives/include/affordance_primitives/screw_model/screw_execution.hpp
+++ b/affordance_primitives/include/affordance_primitives/screw_model/screw_execution.hpp
@@ -80,7 +80,7 @@ public:
   ~APScrewExecutor(){};
 
   bool getScrewTwist(const AffordancePrimitiveGoal & req, AffordancePrimitiveFeedback & feedback);
-  std::vector<PoseStamped> getScrewWaypoints(const AffordancePrimitiveGoal & req, double num_steps);
+  std::vector<AffordanceWaypoint> getScrewWaypoints(const AffordancePrimitiveGoal & req, size_t num_steps);
 
   /**
    * @brief Gets the TF from the moving frame to task frame, either by looking it up or checking the passed one

--- a/affordance_primitives/include/affordance_primitives/screw_model/screw_execution.hpp
+++ b/affordance_primitives/include/affordance_primitives/screw_model/screw_execution.hpp
@@ -81,7 +81,7 @@ public:
 
   bool setStreamingCommands(
     const AffordancePrimitiveGoal & req, AffordancePrimitiveFeedback & feedback);
-  std::vector<AffordanceWaypoint> getTrajectoryCommands(
+  std::optional<AffordanceTrajectory> getTrajectoryCommands(
     const AffordancePrimitiveGoal & req, size_t num_steps);
 
   /**

--- a/affordance_primitives/include/affordance_primitives/screw_model/screw_execution.hpp
+++ b/affordance_primitives/include/affordance_primitives/screw_model/screw_execution.hpp
@@ -80,6 +80,7 @@ public:
   ~APScrewExecutor(){};
 
   bool getScrewTwist(const AffordancePrimitiveGoal & req, AffordancePrimitiveFeedback & feedback);
+  std::vector<PoseStamped> getScrewWaypoints(const AffordancePrimitiveGoal & req, double num_steps);
 
   /**
    * @brief Gets the TF from the moving frame to task frame, either by looking it up or checking the passed one

--- a/affordance_primitives/include/affordance_primitives/screw_model/screw_execution.hpp
+++ b/affordance_primitives/include/affordance_primitives/screw_model/screw_execution.hpp
@@ -33,6 +33,7 @@
 #pragma once
 
 #include <ros/ros.h>
+#include <tf2_eigen/tf2_eigen.h>
 #include <tf2_ros/transform_listener.h>
 
 #include <affordance_primitives/msg_types.hpp>
@@ -58,7 +59,18 @@ Eigen::Matrix<double, 6, 1> calculateAffordanceTwist(const ScrewStamped & screw,
  */
 Eigen::Matrix<double, 6, 1> calculateAffordanceWrench(
   const ScrewStamped & screw, const Eigen::Matrix<double, 6, 1> & twist,
-  double impedance_translation, double impendance_rotation);
+  double impedance_translation, double impedance_rotation);
+
+/**
+ * @brief Calculates the wrench needed at the moving frame to perform the task. Given in moving reference frame
+ * @param affordance_wrench The calculated "afforance wrench", from the task velocity and impedance
+ * @param tf_moving_to_task The transformation from the moving frame to the task frame (i.e. frame screw is defined in)
+ * @param screw The screw message for the AP
+ * @return Wrench defined with respect to the moving frame, representing the F/T the robot needs to apply
+ */
+Eigen::Matrix<double, 6, 1> calculateAppliedWrench(
+  const Eigen::Matrix<double, 6, 1> & affordance_wrench,
+  const Eigen::Isometry3d & tf_moving_to_task, const ScrewStamped & screw);
 
 class APScrewExecutor
 {

--- a/affordance_primitives/src/ap_executor/ap_executor.cpp
+++ b/affordance_primitives/src/ap_executor/ap_executor.cpp
@@ -163,7 +163,7 @@ AffordancePrimitiveResult APExecutor::execute(
     // Otherwise, send commands
     else {
       AffordancePrimitiveFeedback ap_feedback;
-      if (!screw_executor_->getScrewTwist(*goal, ap_feedback)) {
+      if (!screw_executor_->setStreamingCommands(*goal, ap_feedback)) {
         ap_result.result = ap_result.KIN_VIOLATION;
         break;
       }

--- a/affordance_primitives/src/screw_model/affordance_utils.cpp
+++ b/affordance_primitives/src/screw_model/affordance_utils.cpp
@@ -160,6 +160,20 @@ Eigen::MatrixXd getAdjointMatrix(const Transform & transform)
   return getAdjointMatrix(tf2::transformToEigen(transform));
 }
 
+// TODO: add test
+Eigen::Matrix<double, 6, 1> transformTwist(
+  const Eigen::Matrix<double, 6, 1> & twist, const Eigen::Isometry3d & tf)
+{
+  return getAdjointMatrix(tf) * twist;
+}
+
+// TODO: add test
+Eigen::Matrix<double, 6, 1> transformWrench(
+  const Eigen::Matrix<double, 6, 1> & wrench, const Eigen::Isometry3d & tf)
+{
+  return getAdjointMatrix(tf.inverse()).transpose() * wrench;
+}
+
 Eigen::Matrix<double, 6, 1> CartesianFloatToVector(const CartesianFloat & cart_float)
 {
   Eigen::Matrix<double, 6, 1> output;

--- a/affordance_primitives/src/screw_model/affordance_utils.cpp
+++ b/affordance_primitives/src/screw_model/affordance_utils.cpp
@@ -108,6 +108,8 @@ ScrewStamped transformScrew(const ScrewStamped & input_screw, const TransformSta
 
   ScrewStamped output;
   output.header.frame_id = transform.child_frame_id;
+  output.is_pure_translation = input_screw.is_pure_translation;
+  output.pitch = input_screw.pitch;
 
   // Convert to Eigen types
   auto tf_new_to_old = (tf2::transformToEigen(transform.transform)).inverse();

--- a/affordance_primitives/src/screw_model/affordance_utils.cpp
+++ b/affordance_primitives/src/screw_model/affordance_utils.cpp
@@ -160,14 +160,12 @@ Eigen::MatrixXd getAdjointMatrix(const Transform & transform)
   return getAdjointMatrix(tf2::transformToEigen(transform));
 }
 
-// TODO: add test
 Eigen::Matrix<double, 6, 1> transformTwist(
   const Eigen::Matrix<double, 6, 1> & twist, const Eigen::Isometry3d & tf)
 {
   return getAdjointMatrix(tf) * twist;
 }
 
-// TODO: add test
 Eigen::Matrix<double, 6, 1> transformWrench(
   const Eigen::Matrix<double, 6, 1> & wrench, const Eigen::Isometry3d & tf)
 {

--- a/affordance_primitives/src/screw_model/screw_axis.cpp
+++ b/affordance_primitives/src/screw_model/screw_axis.cpp
@@ -165,4 +165,21 @@ Eigen::Isometry3d ScrewAxis::getTF(double delta_theta) const
 
   return output;
 }
+
+std::vector<Eigen::Isometry3d> ScrewAxis::getWaypoints(double theta_step, size_t num_steps)
+{
+  std::vector<Eigen::Isometry3d> output;
+
+  // Check for invalid inputs
+  if (num_steps < 1 || fabs(theta_step) < 1e-8) {
+    return output;
+  }
+
+  // Iterate over number of steps to generate waypoints
+  output.reserve(num_steps);
+  for (size_t i = 1; i < num_steps + 1; i++) {
+    output.push_back(getTF(i * theta_step));
+  }
+  return output;
+}
 }  // namespace affordance_primitives

--- a/affordance_primitives/src/screw_model/screw_axis.cpp
+++ b/affordance_primitives/src/screw_model/screw_axis.cpp
@@ -176,8 +176,8 @@ std::vector<Eigen::Isometry3d> ScrewAxis::getWaypoints(double theta_step, size_t
   }
 
   // Iterate over number of steps to generate waypoints
-  output.reserve(num_steps);
-  for (size_t i = 1; i < num_steps + 1; i++) {
+  output.reserve(num_steps + 1);
+  for (size_t i = 0; i < num_steps + 1; i++) {
     output.push_back(getTF(i * theta_step));
   }
   return output;

--- a/affordance_primitives/src/screw_model/screw_execution.cpp
+++ b/affordance_primitives/src/screw_model/screw_execution.cpp
@@ -84,6 +84,7 @@ bool APScrewExecutor::getScrewTwist(
   feedback.moving_frame_twist.twist = tf2::toMsg(eigen_twist_moving_frame);
   feedback.expected_wrench.header.frame_id = tfmsg_moving_to_task_frame.header.frame_id;
   feedback.expected_wrench.wrench = VectorToWrench(wrench_to_apply);
+  feedback.tf_moving_to_task = tfmsg_moving_to_task_frame;
 
   return true;
 }

--- a/affordance_primitives/src/screw_model/screw_execution.cpp
+++ b/affordance_primitives/src/screw_model/screw_execution.cpp
@@ -58,7 +58,7 @@ Eigen::Matrix<double, 6, 1> calculateAppliedWrench(
 
 APScrewExecutor::APScrewExecutor() : tfListener_(tfBuffer_) {}
 
-bool APScrewExecutor::getScrewTwist(
+bool APScrewExecutor::setStreamingCommands(
   const AffordancePrimitiveGoal & req, AffordancePrimitiveFeedback & feedback)
 {
   // Lookup or check passed TF info
@@ -95,7 +95,7 @@ bool APScrewExecutor::getScrewTwist(
   return true;
 }
 
-std::vector<AffordanceWaypoint> APScrewExecutor::getScrewWaypoints(
+std::vector<AffordanceWaypoint> APScrewExecutor::getTrajectoryCommands(
   const AffordancePrimitiveGoal & req, size_t num_steps)
 {
   // Lookup or check passed TF info

--- a/affordance_primitives/src/screw_model/screw_execution.cpp
+++ b/affordance_primitives/src/screw_model/screw_execution.cpp
@@ -4,7 +4,6 @@
 
 namespace affordance_primitives
 {
-// TODO: add test
 Eigen::Matrix<double, 6, 1> calculateAffordanceTwist(const ScrewStamped & screw, double theta_dot)
 {
   // ScrewAxis does most of the heavy lifting
@@ -18,7 +17,6 @@ Eigen::Matrix<double, 6, 1> calculateAffordanceTwist(const ScrewStamped & screw,
   return affordance_twist;
 }
 
-// TODO: add test
 Eigen::Matrix<double, 6, 1> calculateAffordanceWrench(
   const ScrewStamped & screw, const Eigen::Matrix<double, 6, 1> & twist,
   double impedance_translation, double impedance_rotation)
@@ -36,7 +34,6 @@ Eigen::Matrix<double, 6, 1> calculateAffordanceWrench(
   return affordance_wrench;
 }
 
-// TODO: add test
 Eigen::Matrix<double, 6, 1> calculateAppliedWrench(
   const Eigen::Matrix<double, 6, 1> & affordance_wrench,
   const Eigen::Isometry3d & tf_moving_to_task, const ScrewStamped & screw)

--- a/affordance_primitives/test/test_affordance_utils.cpp
+++ b/affordance_primitives/test/test_affordance_utils.cpp
@@ -222,6 +222,29 @@ TEST(AffordanceUtils, transformScrew)
   checkVector(output_screw_msg.axis, 0, -1, 0);
 }
 
+TEST(AffordanceUtils, transformTwistAndWrench)
+{
+  // Translation [1, 0, 2]
+  // Rotation +90 degrees around X-axis
+  Eigen::Isometry3d tf;
+  tf.translation() = Eigen::Vector3d(1, 0, 2);
+  tf.linear() = Eigen::Quaterniond(sqrt(2) / 2, sqrt(2) / 2, 0, 0).toRotationMatrix();
+
+  // Test twist conversion
+  Eigen::Matrix<double, 6, 1> twist_in_B;
+  twist_in_B << 0, 1.5, -0.5, 0, 0, 1;
+  Eigen::Matrix<double, 6, 1> twist_in_A = affordance_primitives::transformTwist(twist_in_B, tf);
+  checkVector(twist_in_A.head(3), 2, 0.5, 0.5);
+  checkVector(twist_in_A.tail(3), 0, -1, 0);
+
+  // Test wrench conversion
+  Eigen::Matrix<double, 6, 1> wrench_in_B;
+  wrench_in_B << 10, 0, 15, 0, 0, 5;
+  Eigen::Matrix<double, 6, 1> wrench_in_A = affordance_primitives::transformWrench(wrench_in_B, tf);
+  checkVector(wrench_in_A.head(3), 10, -15, 0);
+  checkVector(wrench_in_A.tail(3), 30, 15, -15);
+}
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/affordance_primitives/test/test_screw_axis.cpp
+++ b/affordance_primitives/test/test_screw_axis.cpp
@@ -323,8 +323,8 @@ TEST(ScrewAxis, get_waypoints)
   std::vector<Eigen::Isometry3d> waypoints;
   ASSERT_NO_THROW(waypoints = screw_axis.getWaypoints(theta_step, num_steps));
 
-  // Check output has correct size
-  EXPECT_EQ(waypoints.size(), num_steps);
+  // Check output has correct size (the number of waypoints, plus identity at the start)
+  EXPECT_EQ(waypoints.size(), num_steps + 1);
 
   // Check that the back waypoint matches a 90 degree rotation
   auto last_wp = waypoints.back();

--- a/affordance_primitives/test/test_screw_execution.cpp
+++ b/affordance_primitives/test/test_screw_execution.cpp
@@ -94,7 +94,7 @@ TEST(ScrewExecution, providedTF)
   // Check for bogus input case
   ap_goal.moving_frame_source = -1;
   bool bool_result = true;
-  ASSERT_NO_THROW(bool_result = exec.getScrewTwist(ap_goal, ap_feedback));
+  ASSERT_NO_THROW(bool_result = exec.setStreamingCommands(ap_goal, ap_feedback));
   EXPECT_FALSE(bool_result);
 
   // Set up Screw msg
@@ -110,7 +110,7 @@ TEST(ScrewExecution, providedTF)
   ap_goal.moving_to_task_frame = tf_msg;
   ap_goal.screw = screw_msg;
   bool_result = true;
-  ASSERT_NO_THROW(bool_result = exec.getScrewTwist(ap_goal, ap_feedback));
+  ASSERT_NO_THROW(bool_result = exec.setStreamingCommands(ap_goal, ap_feedback));
   EXPECT_FALSE(bool_result);
 
   // Set up transform msg
@@ -125,7 +125,7 @@ TEST(ScrewExecution, providedTF)
   ap_goal.screw.is_pure_translation = false;
   ap_goal.screw.pitch = 0;
   bool_result = false;
-  ASSERT_NO_THROW(bool_result = exec.getScrewTwist(ap_goal, ap_feedback));
+  ASSERT_NO_THROW(bool_result = exec.setStreamingCommands(ap_goal, ap_feedback));
   EXPECT_TRUE(bool_result);
   checkVector(ap_feedback.moving_frame_twist.twist.linear, 0, 0, -2 * ap_goal.theta_dot);
   checkVector(ap_feedback.moving_frame_twist.twist.angular, 0, -1 * ap_goal.theta_dot, 0);
@@ -140,7 +140,7 @@ TEST(ScrewExecution, providedTF)
   // Check valid screw motion case
   ap_goal.screw.pitch = 1.5;
   bool_result = false;
-  ASSERT_NO_THROW(bool_result = exec.getScrewTwist(ap_goal, ap_feedback));
+  ASSERT_NO_THROW(bool_result = exec.setStreamingCommands(ap_goal, ap_feedback));
   EXPECT_TRUE(bool_result);
   checkVector(
     ap_feedback.moving_frame_twist.twist.linear, 0, -1 * ap_goal.screw.pitch * ap_goal.theta_dot,
@@ -150,7 +150,7 @@ TEST(ScrewExecution, providedTF)
   // Check valid translation case
   ap_goal.screw.is_pure_translation = true;
   bool_result = false;
-  ASSERT_NO_THROW(bool_result = exec.getScrewTwist(ap_goal, ap_feedback));
+  ASSERT_NO_THROW(bool_result = exec.setStreamingCommands(ap_goal, ap_feedback));
   EXPECT_TRUE(bool_result);
   checkVector(ap_feedback.moving_frame_twist.twist.linear, 0, -1 * ap_goal.theta_dot, 0);
   checkVector(ap_feedback.moving_frame_twist.twist.angular, 0, 0, 0);
@@ -175,7 +175,7 @@ TEST(ScrewExecution, lookupTF)
   // If we look up a bogus frame, we expect no exception but a false return
   ap_goal.moving_frame_name = "some_bogus_frame";
   bool bool_result = true;
-  ASSERT_NO_THROW(bool_result = exec.getScrewTwist(ap_goal, ap_feedback));
+  ASSERT_NO_THROW(bool_result = exec.setStreamingCommands(ap_goal, ap_feedback));
   EXPECT_FALSE(bool_result);
 
   // If we lookup the correct frame, we should get good results
@@ -186,7 +186,7 @@ TEST(ScrewExecution, lookupTF)
   ap_goal.screw.is_pure_translation = false;
   ap_goal.screw.pitch = 0;
   bool_result = false;
-  ASSERT_NO_THROW(bool_result = exec.getScrewTwist(ap_goal, ap_feedback));
+  ASSERT_NO_THROW(bool_result = exec.setStreamingCommands(ap_goal, ap_feedback));
   EXPECT_TRUE(bool_result);
   checkVector(ap_feedback.moving_frame_twist.twist.linear, 0, 0, -2 * ap_goal.theta_dot);
   checkVector(ap_feedback.moving_frame_twist.twist.angular, 0, -1 * ap_goal.theta_dot, 0);

--- a/affordance_primitives/test/test_screw_execution.cpp
+++ b/affordance_primitives/test/test_screw_execution.cpp
@@ -48,6 +48,15 @@ inline void checkVector(const affordance_primitives::Vector3 & vec, double x, do
   EXPECT_NEAR(vec.z, z, EPSILON);
 }
 
+inline void checkQuaternion(
+  const affordance_primitives::Quaternion & quat, double x, double y, double z, double w)
+{
+  EXPECT_NEAR(quat.x, x, EPSILON);
+  EXPECT_NEAR(quat.y, y, EPSILON);
+  EXPECT_NEAR(quat.z, z, EPSILON);
+  EXPECT_NEAR(quat.w, w, EPSILON);
+}
+
 /*
     TEST CASE:
 
@@ -114,6 +123,13 @@ TEST(ScrewExecution, providedTF)
   checkVector(ap_feedback.moving_frame_twist.twist.linear, 0, 0, -2 * ap_goal.theta_dot);
   checkVector(ap_feedback.moving_frame_twist.twist.angular, 0, -1 * ap_goal.theta_dot, 0);
 
+  // Check transform matches what we sent
+  EXPECT_EQ(ap_feedback.tf_moving_to_task.header.frame_id, MOVING_FRAME_NAME);
+  EXPECT_EQ(ap_feedback.tf_moving_to_task.child_frame_id, TASK_FRAME_NAME);
+  checkVector(ap_feedback.tf_moving_to_task.transform.translation, 2, 0, 0);
+  checkQuaternion(
+    ap_feedback.tf_moving_to_task.transform.rotation, 0.5 * sqrt(2), 0, 0, 0.5 * sqrt(2));
+
   // Check valid screw motion case
   ap_goal.screw.pitch = 1.5;
   bool_result = false;
@@ -167,6 +183,13 @@ TEST(ScrewExecution, lookupTF)
   EXPECT_TRUE(bool_result);
   checkVector(ap_feedback.moving_frame_twist.twist.linear, 0, 0, -2 * ap_goal.theta_dot);
   checkVector(ap_feedback.moving_frame_twist.twist.angular, 0, -1 * ap_goal.theta_dot, 0);
+
+  // Check the lookup worked and returned correctly
+  EXPECT_EQ(ap_feedback.tf_moving_to_task.header.frame_id, MOVING_FRAME_NAME);
+  EXPECT_EQ(ap_feedback.tf_moving_to_task.child_frame_id, TASK_FRAME_NAME);
+  checkVector(ap_feedback.tf_moving_to_task.transform.translation, 2, 0, 0);
+  checkQuaternion(
+    ap_feedback.tf_moving_to_task.transform.rotation, 0.5 * sqrt(2), 0, 0, 0.5 * sqrt(2));
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
This adds a capability to generate an entire Cartesian trajectory from an AP request. The result includes waypoints as well as twists and wrenches required at each waypoint.

It includes a refactoring of the `APScrewExecutor` class to move a lot of what it was doing to calculate the streaming AP commands to their own functions (for use with trajectory generation as well).