### PR TITLE
Fix local minima in the screw-based path constraint function

### DIFF
--- a/affordance_primitives/include/affordance_primitives/screw_planning/screw_planning.hpp
+++ b/affordance_primitives/include/affordance_primitives/screw_planning/screw_planning.hpp
@@ -36,22 +36,58 @@
 
 #include <affordance_primitives/screw_model/affordance_utils.hpp>
 #include <affordance_primitives/screw_model/screw_axis.hpp>
+#include <queue>
 #include <utility>
 
 namespace affordance_primitives
 {
-bool constraintFn(
+/** Implements the constraint function for a screw-based path
+   *
+   * @param current_pose The we are checking if satisfies the constraint
+   * @param start_pose The first position on the path (when theta = 0)
+   * @param screw_axis The axis to follow
+   * @param theta_limits The (lower, upper) limits for theta
+   * @param theta_guess An initial guess for the theta corresponding to the closest pose on the path
+   * @param out The error between current_pose and the screw path. If the norm of this is 0, the pose is on the path
+   * @return True if everything went well
+   */
+bool screwConstraint(
   const Eigen::Isometry3d & current_pose, const Eigen::Isometry3d & start_pose,
-  const ScrewAxis & screw_axis, double theta_max, double theta_guess,
+  const ScrewAxis & screw_axis, const std::pair<double, double> theta_limits, double theta_guess,
   Eigen::Ref<Eigen::VectorXd> out);
 
+/** Calculates the error vector from a given transformation
+   *
+   * @param tf_err The transformation between two poses
+   * @return A vector representing the error where the first 3 values are the 
+   * translation, and the last 3 are the orientation error in axis-angle format
+   */
 Eigen::VectorXd calcError(const Eigen::Isometry3d & tf_err);
 
 double calcErrorDerivative(
   const Eigen::Isometry3d & tf_m_to_q, const Eigen::Isometry3d & tf_m_to_e,
   const double current_theta, const ScrewAxis & screw_axis);
 
-std::pair<double, Eigen::Isometry3d> findClosestPoint(
+/** Runs gradient descent one time
+   *
+   * @param tf_m_to_q The TF from planning frame to the pose to check
+   * @param tf_m_to_e The TF from planning frame to the starting path pose (when theta = 0)
+   * @param theta_start The theta to start from
+   * @param theta_limits The (lower, upper) bounds on theta
+   * @param screw_axis The screw axis defining the path
+   * @return First: the found theta. Second: the TF from passed pose to closest point on path
+   */
+std::pair<double, Eigen::Isometry3d> runGradientDescent(
   const Eigen::Isometry3d & tf_m_to_q, const Eigen::Isometry3d & tf_m_to_e,
-  const double theta_start, const double theta_max, const ScrewAxis & screw_axis);
+  const double theta_start, const std::pair<double, double> theta_limits,
+  const ScrewAxis & screw_axis);
+
+/** Gets a queue of places to start the gradient descent from
+   *
+   * @param limits The (lower, upper) bounds to search
+   * @param max_dist The maximum distance between starts
+   * @return A queue of places to start gradient descent
+   */
+std::queue<double> getGradStarts(
+  const std::pair<double, double> & limits, double max_dist = 0.5 * M_PI);
 }  // namespace affordance_primitives


### PR DESCRIPTION
This fixes a slight problem with the constraint function for screw planning where it could find a local minimum in the gradient descent. The fix just starts it multiple times.

Because an initial guess is passed into the constraint function (e.g. the screw part of the state message), the multiple starts are rarely used if a valid state is passed. This is because that guess is checked first and if it is close to the constraint, the function is terminated early